### PR TITLE
subtract out some overheads from the max datagram size

### DIFF
--- a/neqo-http3/src/connection_client.rs
+++ b/neqo-http3/src/connection_client.rs
@@ -894,9 +894,12 @@ impl Http3Client {
     ///
     /// This cannot panic. The max varint length is 8.
     pub fn webtransport_max_datagram_size(&self, session_id: StreamId) -> Res<u64> {
+        let session_id_len = u64::try_from(Encoder::varint_len(session_id.as_u64()))
+            .map_err(|_| Error::Internal)?;
+        const DATAGRAM_OVERHEAD: u64 = 64;
         Ok(self.conn.max_datagram_size()?
-            - u64::try_from(Encoder::varint_len(session_id.as_u64()))
-                .map_err(|_| Error::Internal)?)
+            .saturating_sub(session_id_len)
+            .saturating_sub(DATAGRAM_OVERHEAD))
     }
 
     pub fn webtransport_set_datagram_high_water_mark(

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/datagrams.rs
@@ -16,6 +16,8 @@ use crate::{
 };
 
 const DGRAM: &[u8] = &[0, 100];
+// Overhead subtracted by webtransport_max_datagram_size on the client side.
+const CLIENT_DATAGRAM_OVERHEAD: u64 = 64;
 
 #[test]
 fn no_datagrams() {
@@ -63,7 +65,8 @@ fn do_datagram_test(wt: &mut WtTest, wt_session: &WebTransportRequest) {
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
         Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap()
+            - CLIENT_DATAGRAM_OVERHEAD)
     );
 
     assert_eq!(wt_session.send_datagram(DGRAM, None, now(), 0, 0), Ok(()));
@@ -99,7 +102,8 @@ fn datagrams_server_only() {
     assert_eq!(
         wt.max_datagram_size(wt_session.stream_id()),
         Ok(DATAGRAM_SIZE
-            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap())
+            - u64::try_from(Encoder::varint_len(wt_session.stream_id().as_u64())).unwrap()
+            - CLIENT_DATAGRAM_OVERHEAD)
     );
 
     assert_eq!(


### PR DESCRIPTION
Avoids problems where datagrams won't fit with acks, etc